### PR TITLE
Switch to commonjs module, build both es5 and es6 modules, update webpack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # NPM modules
 node_modules/
 lib/
+lib-esm/
 package-lock.json

--- a/package.json
+++ b/package.json
@@ -3,10 +3,15 @@
   "version": "1.1.5",
   "description": "React HOC that helps with panning and zooming elements",
   "main": "lib/panAndZoomHoc.js",
+  "jsnext:main": "lib-esm/panAndZoomHoc.js",
   "types": "lib/panAndZoomHoc.d.ts",
   "scripts": {
-    "build": "rimraf lib && tsc",
-    "clean": "rimraf lib node_modules",
+    "build": "run-s clean:es5 build:es5 clean:es6 build:es6",
+    "build:es5": "tsc",
+    "build:es6": "tsc -m es2015 --outDir lib-esm --declarationDir lib-esm",
+    "clean": "rimraf lib lib-esm node_modules",
+    "clean:es5": "rimraf lib",
+    "clean:es6": "rimraf lib-esm",
     "examples": "webpack-dev-server --config webpack.config.development.babel.js --content-base dist/ --hot --inline --host 0.0.0.0 --port 8888",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -20,7 +25,7 @@
     "url": "https://github.com/woutervh-/react-pan-and-zoom-hoc/issues"
   },
   "homepage": "https://github.com/woutervh-/react-pan-and-zoom-hoc#readme",
-  "dependencies": {
+  "peerDependencies": {
     "prop-types": "^15.6.0",
     "react": "^15.4.0 || ^16.0.0",
     "react-dom": "^15.4.0 || ^16.0.0"
@@ -32,16 +37,17 @@
     "awesome-typescript-loader": "^3.2.3",
     "babel-cli": "^6.18.0",
     "babel-loader": "^6.2.7",
-    "babel-plugin-transform-es2015-modules-umd": "^6.18.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
     "html-webpack-plugin": "^2.24.1",
+    "npm-run-all": "^4.1.1",
+    "prop-types": "^15.6.0",
     "react": "^15.4.0",
     "react-dom": "^15.4.0",
     "rimraf": "^2.5.4",
     "typescript": "^2.5.3",
-    "webpack": "^1.13.3",
-    "webpack-dev-server": "^1.16.2"
+    "webpack": "^3.8.1",
+    "webpack-dev-server": "^2.9.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.5",
   "description": "React HOC that helps with panning and zooming elements",
   "main": "lib/panAndZoomHoc.js",
-  "module": "lib-esm/panAndZoomHoc.js",
+  "jsnext:main": "lib-esm/panAndZoomHoc.js",
   "types": "lib/panAndZoomHoc.d.ts",
   "scripts": {
     "build": "run-s clean:es5 build:es5 clean:es6 build:es6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.1.5",
   "description": "React HOC that helps with panning and zooming elements",
   "main": "lib/panAndZoomHoc.js",
-  "jsnext:main": "lib-esm/panAndZoomHoc.js",
+  "module": "lib-esm/panAndZoomHoc.js",
   "types": "lib/panAndZoomHoc.d.ts",
   "scripts": {
     "build": "run-s clean:es5 build:es5 clean:es6 build:es6",

--- a/src/panAndZoomHoc.tsx
+++ b/src/panAndZoomHoc.tsx
@@ -77,12 +77,6 @@ export default function panAndZoom<P extends PassedOnProps>(WrappedComponent: Re
             }
         }
 
-        handleRef = (ref: React.ReactInstance | null) => {
-            if (ref) {
-                this.element = ReactDOM.findDOMNode(ref);
-            }
-        };
-
         handleWheel = (event: WheelEvent) => {
             const {onPanAndZoom, renderOnChange, onZoom} = this.props;
             const x: number | undefined = this.props.x;
@@ -249,7 +243,6 @@ export default function panAndZoom<P extends PassedOnProps>(WrappedComponent: Re
                     <WrappedComponent
                       {...passedProps}
                       {...other}
-                      ref={this.handleRef}
                       onMouseDown={this.handleMouseDown}
                       onMouseMove={this.handleMouseMove}
                       onMouseUp={this.handleMouseUp}

--- a/src/panAndZoomHoc.tsx
+++ b/src/panAndZoomHoc.tsx
@@ -29,12 +29,8 @@ export interface PassedOnProps {
     scale?: number;
 }
 
-export interface WithElement {
-    getElement: () => Element | null;
-}
-
 export default function panAndZoom<P extends PassedOnProps>(WrappedComponent: React.SFC<P> | React.ComponentClass<P> | string): React.ComponentClass<Overwrite<P, PanAndZoomHOCProps>> {
-    return class PanAndZoomHOC extends React.PureComponent<Overwrite<P, PanAndZoomHOCProps>, any> implements WithElement {
+    return class PanAndZoomHOC extends React.PureComponent<Overwrite<P, PanAndZoomHOCProps>, any> {
         static propTypes = {
             x: PropTypes.number,
             y: PropTypes.number,
@@ -202,10 +198,6 @@ export default function panAndZoom<P extends PassedOnProps>(WrappedComponent: Re
                 }
             }
         };
-
-        getElement() {
-            return this.element;
-        }
 
         handleTouchEnd = (event: React.SyntheticEvent<HTMLElement>) => {
             if (this.panning && event.currentTarget) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,10 @@
 {
   "compilerOptions": {
     "moduleResolution": "node",
-    "target": "es2015",
-    "module": "UMD",
+    "target": "es5",
+    "module": "commonjs",
     "lib": [
       "es2015",
-      "es2016",
-      "es2017",
       "dom"
     ],
     "strict": true,

--- a/webpack.config.development.babel.js
+++ b/webpack.config.development.babel.js
@@ -7,16 +7,16 @@ export default {
     },
     devtool: 'source-map',
     resolve: {
-        extensions: ['', '.js']
+        extensions: ['.js']
     },
     module: {
-        loaders: [
-            {test: /\.js$/, loader: 'babel'}
+        rules: [
+            {test: /\.js$/, loader: 'babel-loader', exclude: /node_modules/}
         ]
     },
     plugins: [
         new HtmlWebpackPlugin({
             title: 'react-pan-and-zoom-hoc examples'
-        }),
+        })
     ]
 };


### PR DESCRIPTION
My earlier PR switched the module from `es2015` to `umd` to avoid some React browser console errors. However, this now causes warnings when building with webpack:

```bash
Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
```

I'm not sure why I didn't have this error before. I've switched the module to `commonjs` and everything works. I think the issue stems from different use cases; `es5` vs. `es6` packaging. I've added a second `es6` build and a `package.json` `jsnext:main` entry for `webpack`/`systemjs`/`rollup` users who want to pull the `es2015` module.

I've also updated the `webpack` dependencies and removed some lingering `ref` code.

Thanks for the work on this project.