### PR TITLE
fix onWheel preventDefault() on Chrome >= v73

### DIFF
--- a/src/panAndZoomHoc.tsx
+++ b/src/panAndZoomHoc.tsx
@@ -68,12 +68,23 @@ export default function panAndZoom<P>(WrappedComponent: React.SFC<P> | React.Com
             }
         }
 
+        componentRef = React.createRef<HTMLElement>();
+
+        componentDidMount() {
+            if (this.componentRef.current) {
+                this.componentRef.current.addEventListener('wheel', this.handleWheel);
+            }
+        }
+
         componentWillUnmount() {
             if (this.panning) {
                 document.removeEventListener('mousemove', this.handleMouseMove);
                 document.removeEventListener('mouseup', this.handleMouseUp);
                 document.removeEventListener('touchmove', this.handleMouseMove);
                 document.removeEventListener('touchend', this.handleMouseUp);
+            }
+            if (this.componentRef.current) {
+                this.componentRef.current.removeEventListener('wheel', this.handleWheel);
             }
         }
 
@@ -265,9 +276,9 @@ export default function panAndZoom<P>(WrappedComponent: React.SFC<P> | React.Com
                     <WrappedComponent
                         {...passedProps}
                         {...other}
+                        ref={this.componentRef}
                         onMouseDown={this.handleMouseDown}
                         onTouchStart={this.handleMouseDown}
-                        onWheel={this.handleWheel}
                     >
                         {children}
                     </WrappedComponent>


### PR DESCRIPTION
`.preventDefault()` doesn't work on `onWheel` on Chrome > v73
This will cause parent element scrolling during zooming by mouse wheel.

Thanks for this great HOC but this bug is blocking us from using it.
Hope you can merge this or you can propose a better fix :)

P.S. Setting css `touch-action: none` doesn't work either.


Reference:
https://github.com/facebook/react/issues/14856
https://www.chromestatus.com/features/6662647093133312