### PR TITLE
Made it possible to disable the "zoom to mouse" feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ npm run examples
 * `renderOnChange` (boolean, default: `false`): if `true`, when panning or zooming, it will force a re-render of the component.
 * `passOnProps` (boolean, default: `false`): if `true`, will pass on the `x`, `y`, and `scale` props to the wrapped component. If `renderOnChange` is also set to `true` this will cause the props (with updated values) to be passed on every time a pan or zoom event occurs.
 * `ignorePanOutside` (boolean, default: `false`): if `true`, when the mouse exits the element the panning will stop. When the mouse re-enters the element, and the mouse button is still down, then panning will resume.
+* `disableZoomToMouse` (boolean, default: `false`): if `true`, the scroll wheel zooming will always scroll to the center regardless of the mouse position.
 * `disableScrollZoom` (boolean, default: `false`): if `true`, the scroll wheel zooming functionality will be disabled.
 * `zoomEndTimeout` (number, default: `500`): after the user has used the scroll wheel to pan/zoom, the component will wait `zoomEndTimeout` milliseconds and then fire `onZoomEnd`. If the user uses the scroll wheel before this time has passed, the timeout will reset.
 * `onPanStart` (function, optional): invoked when the component starts to pan. Receives the following arguments:

--- a/src/panAndZoomHoc.tsx
+++ b/src/panAndZoomHoc.tsx
@@ -15,6 +15,7 @@ export interface PanAndZoomHOCProps {
     passOnProps?: boolean;
     ignorePanOutside?: boolean;
     disableScrollZoom?: boolean;
+    disableZoomToMouse?: boolean;
     zoomEndTimeout?: number;
     shiftBoxZoom?: boolean;
     onPanStart?: (event: MouseEvent | TouchEvent) => void;
@@ -41,6 +42,7 @@ export default function panAndZoom<P = any>(WrappedComponent: React.ElementType<
             passOnProps: PropTypes.bool,
             ignorePanOutside: PropTypes.bool,
             disableScrollZoom: PropTypes.bool,
+            disableZoomToMouse: PropTypes.bool,
             zoomEndTimeout: PropTypes.number,
             onPanStart: PropTypes.func,
             onPanMove: PropTypes.func,
@@ -127,8 +129,8 @@ export default function panAndZoom<P = any>(WrappedComponent: React.ElementType<
                     if (target !== null && target instanceof HTMLElement) {
                         const { top, left, width, height } = target.getBoundingClientRect();
                         const { clientX, clientY } = this.normalizeTouchPosition(event, target);
-                        const dx = (clientX / width - 0.5) / (scale + this.ds);
-                        const dy = (clientY / height - 0.5) / (scale + this.ds);
+                        const dx = this.props.disableZoomToMouse ? 0 : (clientX / width - 0.5) / (scale + this.ds);
+                        const dy = this.props.disableZoomToMouse ? 0 : (clientY / height - 0.5) / (scale + this.ds);
                         const sdx = dx * (1 - 1 / factor);
                         const sdy = dy * (1 - 1 / factor);
 
@@ -327,6 +329,7 @@ export default function panAndZoom<P = any>(WrappedComponent: React.ElementType<
                 passOnProps,
                 ignorePanOutside,
                 disableScrollZoom,
+                disableZoomToMouse,
                 zoomEndTimeout,
                 onZoomEnd,
                 shiftBoxZoom,


### PR DESCRIPTION
See the video: The zoom is always centered regardless of the mouse position: 

![ScreenRecording2019-07-19at0 (1)](https://user-images.githubusercontent.com/5159398/61515680-7d943700-aa03-11e9-9812-40f2c2f0cbe5.gif)